### PR TITLE
Make available the environment vars in an idd debug session.

### DIFF
--- a/debuggers/gdb/gdb_mi_driver.py
+++ b/debuggers/gdb/gdb_mi_driver.py
@@ -1,7 +1,7 @@
 import os
 import json
 
-from pygdbmi.gdbcontroller import GdbController
+from debuggers.gdb.idd_gdb_controller import IDDGdbController
 from driver import Driver
 
 from debuggers.gdb.utils import parse_gdb_line
@@ -11,16 +11,14 @@ regressed_response = []
 
 class GDBMiDebugger(Driver):
     base_gdb_instance = None
-    base_gdbmi_instance = GdbController()
 
     regressed_gdb_instance = None
-    regressed_gdbmi_instance = GdbController()
 
     gdb_instances = None
 
     def __init__(self, base_args, regression_args):
-        self.base_gdb_instance = GdbController()
-        self.regressed_gdb_instance = GdbController()
+        self.base_gdb_instance = IDDGdbController()
+        self.regressed_gdb_instance = IDDGdbController()
 
         self.gdb_instances = { 'base': self.base_gdb_instance, 'regressed': self.regressed_gdb_instance }
 

--- a/debuggers/gdb/idd_gdb_controller.py
+++ b/debuggers/gdb/idd_gdb_controller.py
@@ -1,0 +1,45 @@
+import logging
+import subprocess
+import os
+from distutils.spawn import find_executable
+from typing import Union, List, Optional
+from pygdbmi.gdbcontroller import GdbController
+from pygdbmi.IoManager import IoManager
+from pygdbmi.constants import (
+    DEFAULT_GDB_TIMEOUT_SEC,
+    DEFAULT_TIME_TO_CHECK_FOR_ADDITIONAL_OUTPUT_SEC,
+)
+
+DEFAULT_GDB_LAUNCH_COMMAND = ["gdb", "--nx", "--quiet", "--interpreter=mi3"]
+logger = logging.getLogger(__name__)
+
+class IDDGdbController(GdbController):
+    def spawn_new_gdb_subprocess(self) -> int:
+        if self.gdb_process:
+            logger.debug(
+                "Killing current gdb subprocess (pid %d)" % self.gdb_process.pid
+            )
+            self.exit()
+
+        logger.debug(f'Launching gdb: {" ".join(self.command)}')
+
+        my_env = os.environ.copy()
+
+        # Use pipes to the standard streams
+        self.gdb_process = subprocess.Popen(
+            self.command,
+            shell=False,
+            stdout=subprocess.PIPE,
+            stdin=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=0,
+            env=my_env
+        )
+
+        self.io_manager = IoManager(
+            self.gdb_process.stdin,
+            self.gdb_process.stdout,
+            self.gdb_process.stderr,
+            self.time_to_check_for_additional_output_sec,
+        )
+        return self.gdb_process.pid


### PR DESCRIPTION
Created a subclass from GdbController and assigned the env parameter of the gdb_process subprocess the current terminal environment variables so that they are available within the gdb sessions.