### PR TITLE
Fix GDB PrintState args value.

### DIFF
--- a/debuggers/gdb/gdb_commands.py
+++ b/debuggers/gdb/gdb_commands.py
@@ -87,7 +87,7 @@ class PrintState (gdb.Command):
         registers.append(str(e))
 
     result['locals'] = locals
-    result['args'] = locals
+    result['args'] = args
     result['instructions'] = instructions
     result['registers'] = registers
 


### PR DESCRIPTION
The assignment of the result['args'] variable should be args.