### PR TITLE
Fix: timeout error if script files not specified

### DIFF
--- a/idd.py
+++ b/idd.py
@@ -214,9 +214,9 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Diff Debug for simple debugging!')
     parser.add_argument('-c','--comparator', help='Choose a comparator', default='gdb')
     parser.add_argument('-ba','--base-args', help='Base executable args', default='[]', nargs='+')
-    parser.add_argument('-bs','--base-script-path', help='Base preliminary script file path', default='[]', nargs='+')
+    parser.add_argument('-bs','--base-script-path', help='Base preliminary script file path', default=None, nargs='+')
     parser.add_argument('-ra','--regression-args', help='Regression executable args', default='[]', nargs='+')
-    parser.add_argument('-rs','--regression-script-path', help='Regression prelimminary script file path', default='[]', nargs='+')
+    parser.add_argument('-rs','--regression-script-path', help='Regression prelimminary script file path', default=None, nargs='+')
     parser.add_argument('-r','--remote_host', help='The host of the remote server', default='localhost')
     parser.add_argument('-p','--platform', help='The platform of the remote server: macosx, linux', default='linux')
     parser.add_argument('-t','--triple', help='The target triple: x86_64-apple-macosx, x86_64-gnu-linux', default='x86_64-gnu-linux')
@@ -225,9 +225,9 @@ if __name__ == "__main__":
 
     comperator = args['comparator']
     ba = ' '.join(args['base_args'])
-    bs = ' '.join(args['base_script_path'])
+    bs = ' '.join(args['base_script_path']) if args['base_script_path'] is not None else None
     ra = ' '.join(args['regression_args'])
-    rs = ' '.join(args['regression_script_path'])
+    rs = ' '.join(args['regression_script_path']) if args["regression_script_path"] is not None else None
 
     if comperator == 'gdb':
         from debuggers.gdb.gdb_mi_driver import GDBMiDebugger


### PR DESCRIPTION
Fixes:
```bash
❯ idd -ba ./tmp/fib_loop -ra ./tmp/fib_tail_call
Traceback (most recent call last):
  File "/workspaces/cpp-py/opt/idd/idd.py", line 237, in <module>
    Debugger = GDBMiDebugger(ba, bs, ra, rs)
  File "/workspaces/cpp-py/opt/idd/debuggers/gdb/gdb_mi_driver.py", line 25, in __init__
    self.run_single_raw_command('file ' + base_args, 'base')
  File "/workspaces/cpp-py/opt/idd/debuggers/gdb/gdb_mi_driver.py", line 119, in run_single_raw_command
    raw_result = self.gdb_instances[version].write("{command}\n".format(command = command))
  File "/workspaces/cpp-py/opt/idd/venv/lib/python3.10/site-packages/pygdbmi/gdbcontroller.py", line 125, in write
    return self.io_manager.write(
  File "/workspaces/cpp-py/opt/idd/venv/lib/python3.10/site-packages/pygdbmi/IoManager.py", line 284, in write
    return self.get_gdb_response(
  File "/workspaces/cpp-py/opt/idd/venv/lib/python3.10/site-packages/pygdbmi/IoManager.py", line 104, in get_gdb_response
    raise GdbTimeoutError(
pygdbmi.constants.GdbTimeoutError: Did not get response from gdb after 1 seconds
```