### PR TITLE
ability to attach to a process using pid

### DIFF
--- a/debuggers/gdb/gdb_mi_driver.py
+++ b/debuggers/gdb/gdb_mi_driver.py
@@ -34,24 +34,12 @@ class GDBMiDebugger(Driver):
         self.regressed_gdb_instance.send(((" {command}\n".format(command = command),), {"timeout_sec": 60}))
         
         # wait till base is done
-        raw_result = self.base_gdb_instance.recv()
-        
-        # make sure all output is flushed
-        # time.sleep(.005)
-        self.base_gdb_instance.send((("",), {"timeout_sec": 60}))
-        raw_result += self.base_gdb_instance.recv()
-        
+        raw_result = self.base_gdb_instance.recv()        
         # parse output (base)
         base_response = self.parse_command_output(raw_result)
         
         # wait till regression is done
-        raw_result = self.regressed_gdb_instance.recv()
-        
-        # make sure all output is flushed
-        # time.sleep(.005)
-        self.regressed_gdb_instance.send((("",), {"timeout_sec": 60}))
-        raw_result += self.regressed_gdb_instance.recv()
-        
+        raw_result = self.regressed_gdb_instance.recv()        
         # parse output regression
         regressed_response = self.parse_command_output(raw_result)
 
@@ -72,12 +60,7 @@ class GDBMiDebugger(Driver):
         
         self.gdb_instances[version].send(((" {command}\n".format(command = command),), {"timeout_sec": 60}))
         raw_result = self.gdb_instances[version].recv()
-        
-        # make sure all output is flushed
-        # time.sleep(.005)
-        self.gdb_instances[version].send((("",), {"timeout_sec": 60}))
-        raw_result += self.gdb_instances[version].recv()
-        
+
         return self.parse_command_output(raw_result)
 
     def run_single_special_command(self, command, version):
@@ -86,10 +69,6 @@ class GDBMiDebugger(Driver):
 
         self.gdb_instances[version].send(((" {command}\n".format(command = command),), {"timeout_sec": 60}))
         raw_result = self.gdb_instances[version].recv()
-
-        # flush output
-        self.gdb_instances[version].send((("",), {"timeout_sec": 60}))
-        raw_result += self.gdb_instances[version].recv()
 
         return self.parse_special_command_output(raw_result)
 

--- a/debuggers/gdb/gdb_mi_driver.py
+++ b/debuggers/gdb/gdb_mi_driver.py
@@ -16,14 +16,22 @@ class GDBMiDebugger(Driver):
 
     gdb_instances = None
 
-    def __init__(self, base_args, base_script_file_path, regression_args, regression_script_file_path):
+    def __init__(self, base_args, base_script_file_path, regression_args, regression_script_file_path,
+                 base_pid=None, regression_pid=None):
         self.base_gdb_instance = create_IDDGdbController(base_script_file_path)
         self.regressed_gdb_instance = create_IDDGdbController(regression_script_file_path)
 
         self.gdb_instances = { 'base': self.base_gdb_instance, 'regressed': self.regressed_gdb_instance }
 
-        self.run_single_raw_command('file ' + base_args, 'base')
-        self.run_single_raw_command('file ' + regression_args, 'regressed')
+        if base_pid is None:
+            self.run_single_raw_command('file ' + base_args, 'base')
+        else:
+            self.run_single_raw_command('attach ' + base_pid, 'base')
+        
+        if regression_pid is None:
+            self.run_single_raw_command('file ' + regression_args, 'regressed')
+        else:
+            self.run_single_raw_command('attach ' + regression_pid, 'regressed')
 
         dirname = os.path.dirname(__file__)
         self.run_parallel_raw_command("source " + os.path.join(dirname, "gdb_commands.py"))

--- a/debuggers/gdb/gdb_mi_driver.py
+++ b/debuggers/gdb/gdb_mi_driver.py
@@ -42,12 +42,12 @@ class GDBMiDebugger(Driver):
         self.regressed_gdb_instance.send(((" {command}\n".format(command = command),), {"timeout_sec": 60}))
         
         # wait till base is done
-        raw_result = self.base_gdb_instance.recv()        
+        raw_result = self.base_gdb_instance.recv()
         # parse output (base)
         base_response = self.parse_command_output(raw_result)
         
         # wait till regression is done
-        raw_result = self.regressed_gdb_instance.recv()        
+        raw_result = self.regressed_gdb_instance.recv()
         # parse output regression
         regressed_response = self.parse_command_output(raw_result)
 


### PR DESCRIPTION
Fixes #28 

Test with
```c
// pid_example.c

#include <unistd.h>
#include <stdio.h>


void func_to_debug(int argc, char *argv[]) {
    if (argc > 1) {
        for (int i = 1; i < argc; i++) {
            printf("%s\n", argv[i]);
        }
    } else {
        printf("No Arguments\n");
    }
}

int main(int argc, char *argv[]) {
    printf("pid: %d\n", getpid());
    getchar();
    func_to_debug(argc, argv);
    return 0;
}
```

Set a breakpoint at `func_to_debug` after launching idd. Then continue execution. `getchar` is used to suspend execution, to attach gdb.

---

The initial two commits in this PR are related to the old PR (parallel execution using multiprocessing).
They were small changes, so I thought of combining them.