### PR TITLE
[lldb comparator] raise error if executable is not found

### DIFF
--- a/debuggers/lldb/lldb_driver.py
+++ b/debuggers/lldb/lldb_driver.py
@@ -29,9 +29,13 @@ class LLDBDebugger(Driver):
 
         base_error = lldb.SBError()
         base_target = self.base_lldb_instance.CreateTarget(base_args, "x86_64", "host", True, base_error)
+        if not base_error.Success():
+            raise Exception(base_error.GetCString())
 
         regression_error = lldb.SBError()
         regression_target = self.regression_lldb_instance.CreateTarget(regression_args, "x86_64", "host", True, regression_error)
+        if not regression_error.Success():
+            raise Exception(regression_error.GetCString())
 
         self.base_command_interpreter = self.base_lldb_instance.GetCommandInterpreter()
         self.regression_command_interpreter = self.regression_lldb_instance.GetCommandInterpreter()


### PR DESCRIPTION
Example
```python
❯ idd -c lldb -ba ../../tmp/idd-demo/fib_loo -ra ../../tmp/idd-demo/fib_tail_cal
Traceback (most recent call last):
  File "/workspaces/cpp-py/opt/idd/idd.py", line 362, in <module>
    Debugger = LLDBDebugger(ba, ra)
  File "/workspaces/cpp-py/opt/idd/debuggers/lldb/lldb_driver.py", line 33, in __init__
    raise Exception(base_error.GetCString())
Exception: unable to find executable for '../../tmp/idd-demo/fib_loo'
```