### PR TITLE
[lldb comparator] fix: stack none displayed when execution is completed

### DIFF
--- a/debuggers/lldb/lldb_extensions.py
+++ b/debuggers/lldb/lldb_extensions.py
@@ -13,6 +13,8 @@ def get_current_stack_frame_from_target(target):
         if not function:
             # No debug info for 'function'.
             symbol = frame.GetSymbol()
+            if not symbol:
+                continue
             file_addr = addr.GetFileAddress()
             start_addr = symbol.GetStartAddress().GetFileAddress()
             symbol_name = symbol.GetName()


### PR DESCRIPTION
Without this change
![image](https://github.com/user-attachments/assets/2f5be76f-3ebe-461c-a972-bd54caa84a33)


With this change
![image](https://github.com/user-attachments/assets/30be2409-18be-4caf-9a4e-fa0e1b91d679)
