### PR TITLE
[lldb comparator] ability to execute in parallel

### DIFF
--- a/debuggers/gdb/idd_gdb_controller.py
+++ b/debuggers/gdb/idd_gdb_controller.py
@@ -1,6 +1,7 @@
 import logging
 import subprocess
 
+from driver import IDDParallelTerminate
 from pygdbmi.gdbcontroller import GdbController
 from pygdbmi.IoManager import IoManager
 from pygdbmi.constants import (
@@ -54,9 +55,6 @@ class IDDGdbController(GdbController):
         )
         return self.gdb_process.pid
 
-
-class IDDParallelTerminate:
-    pass
 
 
 class IDDParallelGdbController:

--- a/driver.py
+++ b/driver.py
@@ -3,6 +3,9 @@ from abc import ABCMeta, abstractmethod
 
 class Driver(metaclass=abc.ABCMeta):
     @abstractmethod
+    def get_state(self, target): raise NotImplementedError
+
+    @abstractmethod
     def run_single_command(self, command, target): raise NotImplementedError
 
     @abstractmethod
@@ -10,3 +13,7 @@ class Driver(metaclass=abc.ABCMeta):
     
     @abstractmethod
     def terminate(self): raise NotImplementedError
+
+
+class IDDParallelTerminate:
+    pass

--- a/idd.py
+++ b/idd.py
@@ -353,11 +353,11 @@ if __name__ == "__main__":
                 Debugger = GDBMiDebugger(ba, bs, ra, rs)
 
     elif comparator == 'lldb':
-        from debuggers.lldb.lldb_driver import LLDBDebugger
+        from debuggers.lldb.lldb_driver import LLDBParallelDebugger
 
         if ba == "" or ra == "":
             raise Exception("LLDB can only be used by launching executable and executable is not provided")
-        Debugger = LLDBDebugger(ba, ra)
+        Debugger = LLDBParallelDebugger(ba, ra)
     else:
         sys.exit("Invalid comparator set")
 


### PR DESCRIPTION
`LLDBDebugger` handles only 1 lldb instance (similar to `IDDGdbController`) 
`LLDBParallelDebugger` handles 2 instance of `LLDBDebugger` and is responsible for parallel execution

---

Works similar to #29 

Test with

```c
// main.c

#include<unistd.h>

int main() {
    sleep(5); // sleep for 5 secs
    return 1;
}
```

Previously it would take ~10.5 secs. Now it takes ~5.5 secs.