### PR TITLE
chore: minor cleanup to compile script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+/test/*/a/*
+/test/*/b/*

--- a/idd.py
+++ b/idd.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 import sys
 

--- a/test/compile_tests.py
+++ b/test/compile_tests.py
@@ -1,19 +1,20 @@
-#!/usr/bin/env python
-# coding: utf-8
+#!/usr/bin/env python3
 
-import glob
-import os
-from os import system
-root_tests_dir = '.'
+import subprocess
+from pathlib import Path
 
-for test_dir in os.listdir(root_tests_dir):
-    if os.path.isdir(os.path.join(root_tests_dir, test_dir)):
+root_tests_dir = Path(__file__).parent.resolve()
+prog = "g++"
+
+for test_dir in root_tests_dir.iterdir():
+    if test_dir.is_dir():
         print(test_dir)
-        if not os.path.exists("{test_dir}/a".format(test_dir = test_dir)):
-            os.makedirs("{test_dir}/a".format(test_dir = test_dir))
+        a_dir = test_dir / "a"
+        b_dir = test_dir / "b"
 
-        if not os.path.exists("{test_dir}/b".format(test_dir = test_dir)):
-            os.makedirs("{test_dir}/b".format(test_dir = test_dir))
+        a_dir.mkdir(exist_ok=True)
+        b_dir.mkdir(exist_ok=True)
 
-        system("g++ -DV1 -o {test_d}/a/program.out -xc++ -g {test_files}".format(test_d = test_dir, test_files = ' '.join(glob.glob(test_dir + '/*.c??'))))
-        system("g++ -DV2 -o {test_d}/b/program.out -xc++ -g {test_files}".format(test_d = test_dir, test_files = ' '.join(glob.glob(test_dir + '/*.c??'))))
+        test_files = list(test_dir.glob('*.c??'))
+        subprocess.run([prog, "-DV1", "-o", a_dir/"program.out", "-g", *test_files], check=True)
+        subprocess.run([prog, "-DV2", "-o", b_dir/"program.out", "-g", *test_files], check=True)


### PR DESCRIPTION
Some touchup. This makes it easier to swap g++ for clang++ and run from other directories. Also `python` is no longer required to be defined (and is not for me), so using `python3`. Also making some things executable that weren't.

Haven't been able to try it out fully yet on my Mac, as after signing my gdb executable, it just hangs when running one of the `simple` examples (can't even Ctrl-\ it). And I haven't been able to use `lldb` yet as idd requires the Python lldb bindings, which I believe aren't trivial to access.