### PR TITLE
usage without regressed program & [lldb] attach using pid

### DIFF
--- a/debuggers/gdb/gdb_mi_driver.py
+++ b/debuggers/gdb/gdb_mi_driver.py
@@ -1,7 +1,7 @@
 import os
 import json
 
-from debuggers.gdb.idd_gdb_controller import create_IDDGdbController, terminate_all_IDDGdbController
+from debuggers.gdb.idd_gdb_controller import create_IDDGdbController, terminate_all_IDDGdbController, IDDGdbController
 from driver import Driver
 
 from debuggers.gdb.utils import parse_gdb_line
@@ -18,23 +18,10 @@ class GDBMiDebugger(Driver):
 
     def __init__(self, base_args, base_script_file_path, regression_args, regression_script_file_path,
                  base_pid=None, regression_pid=None):
-        self.base_gdb_instance = create_IDDGdbController(base_script_file_path)
-        self.regressed_gdb_instance = create_IDDGdbController(regression_script_file_path)
+        self.base_gdb_instance = create_IDDGdbController(base_args, base_pid, base_script_file_path)
+        self.regressed_gdb_instance = create_IDDGdbController(regression_args, regression_pid, regression_script_file_path)
 
         self.gdb_instances = { 'base': self.base_gdb_instance, 'regressed': self.regressed_gdb_instance }
-
-        if base_pid is None:
-            self.run_single_raw_command('file ' + base_args, 'base')
-        else:
-            self.run_single_raw_command('attach ' + base_pid, 'base')
-        
-        if regression_pid is None:
-            self.run_single_raw_command('file ' + regression_args, 'regressed')
-        else:
-            self.run_single_raw_command('attach ' + regression_pid, 'regressed')
-
-        dirname = os.path.dirname(__file__)
-        self.run_parallel_raw_command("source " + os.path.join(dirname, "gdb_commands.py"))
 
     def run_parallel_command(self, command):
         # start both execution in parallel

--- a/layout.tcss
+++ b/layout.tcss
@@ -20,9 +20,25 @@ TextScrollView {
 }
 
 .row3, .row5 {
-    height: 6%;
+    height: 5%;
 }
 
 .row4 {
     height: 40%;
+}
+
+.base_only_row1 {
+    height: 20%
+}
+
+.base_only_row2 {
+    height: 30%
+}
+
+.base_only_row3 {
+    height: 44%
+}
+
+.base_only_row4 {
+    height: 6%
 }


### PR DESCRIPTION
This PR adds 2 features:
1. Ability to use idd without any regressed program
2. Attach using process ID when using the lldb comparator

---

Example for 1:
```bash
python ./idd.py -ba ./tmp/a/program.out
```

![image](https://github.com/user-attachments/assets/d2d7d6b1-f03f-4470-aa15-c4c2fa4188b4)

Example for 2:
```bash
python ./idd.py -c lldb -bpid 22147 -rpid 22144
```

![image](https://github.com/user-attachments/assets/d1d43183-1d4f-49f5-9465-c7f7830e06a4)