### PR TITLE
[lldb] enable stdin with `stdin` command

### DIFF
--- a/src/idd/cli.py
+++ b/src/idd/cli.py
@@ -313,7 +313,12 @@ class DiffDebug(App):
                 self.parallel_command_bar.value == "exit":
                 Debugger.terminate()
                 exit(0)
-            if self.parallel_command_bar.value != "":
+            
+            if self.parallel_command_bar.value.startswith("stdin "):
+                Debugger.insert_stdin(self.parallel_command_bar.value[6:] + "\n")
+                result = {}
+            
+            elif self.parallel_command_bar.value != "":
                 result = Debugger.run_parallel_command(self.parallel_command_bar.value)
 
                 self.diff_area1.append([self.parallel_command_bar.value])
@@ -330,7 +335,8 @@ class DiffDebug(App):
                 self.diff_area1.append([self.parallel_command_bar.value])
                 self.diff_area2.append([self.parallel_command_bar.value])
 
-            await self.set_common_command_result(result)
+            if result:
+                await self.set_common_command_result(result)
 
             self.parallel_command_bar.value = ""
 
@@ -338,7 +344,11 @@ class DiffDebug(App):
             if self.only_base and (self.base_command_bar.value == "exit" or self.base_command_bar.value == "quit"):
                 Debugger.terminate()
                 exit(0)
-            if self.base_command_bar.value != "":
+            
+            if self.base_command_bar.value.startswith("stdin "):
+                Debugger.insert_stdin_single(self.base_command_bar.value[6:] + "\n", "base")
+
+            elif self.base_command_bar.value != "":
                 result = Debugger.run_single_command(self.base_command_bar.value, "base")
                 self.diff_area1.append([self.base_command_bar.value])
                 self.diff_area1.append(result)
@@ -359,7 +369,10 @@ class DiffDebug(App):
             self.base_command_bar.value = ""
 
         elif event.control.id == 'regressed-command-bar':
-            if self.regressed_command_bar.value != "":
+            if self.regressed_command_bar.value.startswith("stdin "):
+                Debugger.insert_stdin_single(self.regressed_command_bar.value[6:] + "\n", "regressed")
+
+            elif self.regressed_command_bar.value != "":
                 result = Debugger.run_single_command(self.regressed_command_bar.value, "regressed")
                 self.diff_area2.append([self.regressed_command_bar.value])
                 self.diff_area2.append(result)

--- a/src/idd/debuggers/lldb/lldb_driver.py
+++ b/src/idd/debuggers/lldb/lldb_driver.py
@@ -12,6 +12,12 @@ processes = []
 class LLDBGetState:
     pass
 
+
+class LLDBStdin:
+    def __init__(self, text: str):
+        self.text = text
+
+
 class LLDBDebugger:
     is_initted = False
 
@@ -93,6 +99,9 @@ class LLDBDebugger:
         target = self.lldb_instance.GetTargetAtIndex(0)
         calls = get_call_instructions(target)
         return calls
+    
+    def insert_stdin(self, text: str):
+        self.target.GetProcess().PutSTDIN(text)
 
     def terminate(self):
         return
@@ -107,6 +116,8 @@ class LLDBDebugger:
             if isinstance(args, LLDBGetState) or isinstance(kwargs, LLDBGetState):
                 res = lldb.get_state()
                 pipe.send(res)
+            elif isinstance(args, LLDBStdin):
+                lldb.insert_stdin(args.text)
             else:
                 res = lldb.run_single_command(*args, **kwargs)
                 stdout = lldb.target.GetProcess().GetSTDOUT(1024 * 1024 * 10)
@@ -156,6 +167,18 @@ class LLDBParallelDebugger(Driver):
             "base": self.base_pipe.recv(),
             "regressed": self.regressed_pipe.recv(),
         }
+    
+    def insert_stdin(self, text: str):
+        text = LLDBStdin(text)
+        self.base_pipe.send((text, text))
+        self.regressed_pipe.send((text, text))
+    
+    def insert_stdin_single(self, text: str, target: str):
+        text = LLDBStdin(text)
+        if target == "base":
+            self.base_pipe.send((text, text))
+        if target == "regressed":
+            self.regressed_pipe.send((text, text))
     
     def terminate(self):
         terminate_all_IDDGdbController()


### PR DESCRIPTION
This is a tricky implementation.
Say the program uses `scanf` to read input. The user will need to populate stdin before the call to `scanf`. Otherwise, the program will freeze, because `scanf` is trying to read, but `stdin` is not populated.

Note: Using the `stdin` command with gdb will raise AttributeError for now (Not implemented with the gdb backend).

Try with:
```c
// a/fib.c
#include <stdio.h>
#include <stdlib.h>


int internal_fib(int a, int b, int n) {
    if (n < 2)
        return b;
    return internal_fib(b, a + b, n - 1);
}

int fib(int x) {
    return internal_fib(0, 1, x);
}

int main(int argc, char *argv[]) {
    int x = 2;
    printf("Enter number: ");
    scanf("%d", &x);
    printf("%d\n", fib(x));
    return 0;
}
```

```c
// b/fib.c
#include <stdio.h>
#include <stdlib.h>


int internal_fib(int a, int b, int n) {
    while (--n) {
        int tmp = a;
        a = b;
        b = tmp + b;
    }
    return a;
}

int fib(int x) {
    return internal_fib(0, 1, x);
}

int main(int argc, char *argv[]) {
    int x = 2;
    printf("Enter number: ");
    scanf("%d", &x);
    printf("%d\n", fib(x));
    return 0;
}
```

Example:

https://github.com/user-attachments/assets/8ed19d1f-918f-4866-8a6c-8097a6a40a18


