### PR TITLE
Fix text selection from the panes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: PyPI Upload
 
 on:
-  release:
-    types:
-      - published
+  push:
+    tags:
+      - [ 'v*.*.*' ]
 
 jobs:
   dist:

--- a/src/idd/cli.py
+++ b/src/idd/cli.py
@@ -16,6 +16,9 @@ from idd.ui.footer import Footer
 from idd.ui.header import Header
 from idd.ui.scrollable_area import TextScrollView
 
+import os
+import time
+
 
 class DiffDebug(App):
     CSS_PATH = "layout.tcss"
@@ -28,6 +31,19 @@ class DiffDebug(App):
     diff_driver = DiffDriver()
     base_args = ""
     regression_args = ""
+
+    # Terminal-specific selection tips
+    # VSCode : Paste this in user settings: "terminal.integrated.macOptionClickForcesSelection": true
+    SELECTION_TIPS = {
+        "Terminal.app": "Option(⌥)+Click to select text OR Cmd(⌘)+R and select",
+        "iTerm2": "Cmd(⌘)+Shift+C: Copy mode | Option(⌥)+Click: Selection",
+        "Warp": "Shift+Click to select text",
+        "vscode": "Option(⌥)+Click",
+        "default": "Use terminal's selection mechanism to copy text (Maybe Shift+Click)"
+    }
+
+    # Track if we've shown the tip for this panel
+    tip_shown = False
 
     diff_area1 = TextScrollView(title="Base Diff", component_id="diff-area1")
     diff_area2 = TextScrollView(title="Regression Diff", component_id = "diff-area2")
@@ -60,6 +76,10 @@ class DiffDebug(App):
         self.base_history_index = 0
         self.regressed_history = [""]
         self.regressed_history_index = 0
+        self._hover_start = 0
+        self._clicked = False
+        terminal = self._get_terminal_type()
+        self.tip = self.SELECTION_TIPS.get(terminal, self.SELECTION_TIPS["default"])
 
     async def set_command_result(self, version) -> None:
         state = Debugger.get_state(version)
@@ -424,6 +444,48 @@ class DiffDebug(App):
                 return
             
             self.regressed_command_bar.value = self.regressed_history[self.regressed_history_index]
+
+
+    def _get_terminal_type(self):
+        """Try to detect terminal type from environment variables."""
+        term_program = os.environ.get("TERM_PROGRAM", "")
+        if "iTerm" in term_program:
+            return "iTerm2"
+        elif "Apple_Terminal" in term_program:
+            return "Terminal.app"
+        elif "WarpTerminal" in term_program:
+            return "Warp"
+        elif "vscode" in term_program:
+            return "vscode"
+        return "default"
+    
+    def on_mouse_down(self, event: events.MouseDown) -> None:
+        """Track when the user clicks on the panel."""
+        self._clicked = True
+        self._hover_start = time.time()  # Start timing from the click
+    
+    def on_mouse_move(self, event: events.MouseMove) -> None:
+        """Show selection tip after clicking and hovering."""
+        # Only show tip if we've been clicked and haven't shown a tip yet
+        if self._clicked and not self.tip_shown:
+            current_time = time.time()
+            hover_duration = current_time - self._hover_start
+            
+            # Show tip after 0.1 seconds of hovering after a click
+            if hover_duration > 0.1:
+                self.notify(self.tip, severity="information", timeout=3)
+                self.tip_shown = True 
+    
+    def on_mouse_up(self, event: events.MouseUp) -> None:
+        """Reset click state when mouse button is released."""
+        self._clicked = False
+        self.tip_shown = False
+
+    
+    def on_leave(self, event: events.Leave) -> None:
+        """Reset hover timer and click state when mouse leaves the widget."""
+        self._hover_start = 0
+        self._clicked = False
 
 
 Debugger = None

--- a/src/idd/ui/scrollable_area.py
+++ b/src/idd/ui/scrollable_area.py
@@ -4,7 +4,6 @@ import time
 from textual.widgets import RichLog
 from textual import events
 from textual.reactive import reactive
-import time
 
 
 class TextScrollView(RichLog):

--- a/src/idd/ui/scrollable_area.py
+++ b/src/idd/ui/scrollable_area.py
@@ -14,8 +14,7 @@ class TextScrollView(RichLog):
     DEFAULT_CSS = """
     TextScrollView {
         height: 100%;
-        scrollbar-size: 1 1;
-        border: solid green;
+        scrollbar-size: 1 1;  
     }
     """
 

--- a/src/idd/ui/scrollable_area.py
+++ b/src/idd/ui/scrollable_area.py
@@ -1,9 +1,5 @@
 from __future__ import annotations
-import os
-import time
 from textual.widgets import RichLog
-from textual import events
-from textual.reactive import reactive
 
 
 class TextScrollView(RichLog):
@@ -14,27 +10,15 @@ class TextScrollView(RichLog):
     DEFAULT_CSS = """
     TextScrollView {
         height: 100%;
-        scrollbar-size: 1 1;  
+        scrollbar-size: 1 1;
     }
     """
-
-    # Terminal-specific selection tips
-    SELECTION_TIPS = {
-        "Terminal.app": "Option(⌥)+Click to select text",
-        "iTerm2": "Cmd(⌘)+Shift+C: Copy mode | Option(⌥)+Click: Selection",
-        "Warp": "Shift+Click to select text",
-        "default": "Use terminal's selection mechanism to copy text" #default mac terminal
-    }
-    
-    # Track if we've shown the tip for this panel
-    tip_shown = reactive(False)
 
     def __init__(self, title: str = "", component_id: str = None) -> None:
         super().__init__(name=title, auto_scroll=True, markup=True)
         self.border_title = title
         if component_id:
             self.id = component_id
-        self._hover_start = 0
 
     def append(self, lines: list[str]):
         self.write("\n".join(lines))
@@ -42,45 +26,3 @@ class TextScrollView(RichLog):
     def text(self, lines: list[str]):
         self.clear()
         self.append(lines)
-        
-    def _get_terminal_type(self):
-        """Try to detect terminal type from environment variables."""
-        term_program = os.environ.get("TERM_PROGRAM", "")
-        if "iTerm" in term_program:
-            return "iTerm2"
-        elif "Apple_Terminal" in term_program:
-            return "Terminal.app"
-        elif "WarpTerminal" in term_program:
-            return "Warp"
-        return "default"
-    
-    def on_mouse_down(self, event: events.MouseDown) -> None:
-        """Track when the user clicks on the panel."""
-        self._clicked = True
-        self._hover_start = time.time()  # Start timing from the click
-    
-    def on_mouse_move(self, event: events.MouseMove) -> None:
-        """Show selection tip after clicking and hovering."""
-        # Only show tip if we've been clicked and haven't shown a tip yet
-        if hasattr(self, '_clicked') and self._clicked and not self.tip_shown:
-            current_time = time.time()
-            hover_duration = current_time - self._hover_start
-            
-            # Show tip after 0.1 seconds of hovering after a click
-            if hover_duration > 0.1:
-                terminal = self._get_terminal_type()
-                tip = self.SELECTION_TIPS.get(terminal, self.SELECTION_TIPS["default"])
-                self.notify(tip, severity="information", timeout=5)
-                self.tip_shown = True 
-    
-    def on_mouse_up(self, event: events.MouseUp) -> None:
-        """Reset click state when mouse button is released."""
-        if hasattr(self, '_clicked'):
-            self._clicked = False
-    
-    def on_leave(self, event: events.Leave) -> None:
-        """Reset hover timer and click state when mouse leaves the widget."""
-        self._hover_start = 0
-        if hasattr(self, '_clicked'):
-            self._clicked = False
-    

--- a/src/idd/ui/scrollable_area.py
+++ b/src/idd/ui/scrollable_area.py
@@ -36,15 +36,12 @@ class TextScrollView(RichLog):
         if component_id:
             self.id = component_id
         self._hover_start = 0
-        self._content = []
 
     def append(self, lines: list[str]):
-        self._content.extend(lines)
         self.write("\n".join(lines))
 
     def text(self, lines: list[str]):
         self.clear()
-        self._content = lines.copy()
         self.append(lines)
         
     def _get_terminal_type(self):
@@ -88,13 +85,3 @@ class TextScrollView(RichLog):
         if hasattr(self, '_clicked'):
             self._clicked = False
     
-    def export_content(self, filename=None) -> str:
-        """Export content to a file or return it as a string."""
-        text = "\n".join(self._content)
-        if filename and text:
-            try:
-                with open(filename, "w") as f:
-                    f.write(text)
-            except Exception as e:
-                print(f"Error saving to {filename}: {e}")
-        return text

--- a/src/idd/ui/scrollable_area.py
+++ b/src/idd/ui/scrollable_area.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
+import os
+import time
 from textual.widgets import RichLog
+from textual import events
+from textual.reactive import reactive
+import time
 
 
 class TextScrollView(RichLog):
@@ -11,18 +16,86 @@ class TextScrollView(RichLog):
     TextScrollView {
         height: 100%;
         scrollbar-size: 1 1;
+        border: solid green;
     }
     """
+
+    # Terminal-specific selection tips
+    SELECTION_TIPS = {
+        "Terminal.app": "Option(⌥)+Click to select text",
+        "iTerm2": "Cmd(⌘)+Shift+C: Copy mode | Option(⌥)+Click: Selection",
+        "Warp": "Shift+Click to select text",
+        "default": "Use terminal's selection mechanism to copy text" #default mac terminal
+    }
+    
+    # Track if we've shown the tip for this panel
+    tip_shown = reactive(False)
 
     def __init__(self, title: str = "", component_id: str = None) -> None:
         super().__init__(name=title, auto_scroll=True, markup=True)
         self.border_title = title
         if component_id:
             self.id = component_id
+        self._hover_start = 0
+        self._content = []
 
     def append(self, lines: list[str]):
+        self._content.extend(lines)
         self.write("\n".join(lines))
 
     def text(self, lines: list[str]):
         self.clear()
+        self._content = lines.copy()
         self.append(lines)
+        
+    def _get_terminal_type(self):
+        """Try to detect terminal type from environment variables."""
+        term_program = os.environ.get("TERM_PROGRAM", "")
+        if "iTerm" in term_program:
+            return "iTerm2"
+        elif "Apple_Terminal" in term_program:
+            return "Terminal.app"
+        elif "WarpTerminal" in term_program:
+            return "Warp"
+        return "default"
+    
+    def on_mouse_down(self, event: events.MouseDown) -> None:
+        """Track when the user clicks on the panel."""
+        self._clicked = True
+        self._hover_start = time.time()  # Start timing from the click
+    
+    def on_mouse_move(self, event: events.MouseMove) -> None:
+        """Show selection tip after clicking and hovering."""
+        # Only show tip if we've been clicked and haven't shown a tip yet
+        if hasattr(self, '_clicked') and self._clicked and not self.tip_shown:
+            current_time = time.time()
+            hover_duration = current_time - self._hover_start
+            
+            # Show tip after 0.1 seconds of hovering after a click
+            if hover_duration > 0.1:
+                terminal = self._get_terminal_type()
+                tip = self.SELECTION_TIPS.get(terminal, self.SELECTION_TIPS["default"])
+                self.notify(tip, severity="information", timeout=5)
+                self.tip_shown = True 
+    
+    def on_mouse_up(self, event: events.MouseUp) -> None:
+        """Reset click state when mouse button is released."""
+        if hasattr(self, '_clicked'):
+            self._clicked = False
+    
+    def on_leave(self, event: events.Leave) -> None:
+        """Reset hover timer and click state when mouse leaves the widget."""
+        self._hover_start = 0
+        if hasattr(self, '_clicked'):
+            self._clicked = False
+    
+    def export_content(self, filename=None) -> str:
+        """Export content to a file or return it as a string."""
+        text = "\n".join(self._content)
+        if filename and text:
+            try:
+                with open(filename, "w") as f:
+                    f.write(text)
+            except Exception as e:
+                print(f"Error saving to {filename}: {e}")
+        return text


### PR DESCRIPTION
This PR introduces tips/advice for users when they try selecting text from the panes. Every time a user makes the action of "selection" by clicking and scrolling on text from the panels, a temporary message displays.

The commands for the "selection" action is specific to terminals and this implementation checks for the terminal type to show the appropriate tip. 

Addresses issue #44 
