### PR TITLE
[wip] Fix all linter issues with idd picked up by ruff

### DIFF
--- a/src/idd/cli.py
+++ b/src/idd/cli.py
@@ -3,7 +3,6 @@
 import argparse
 import sys
 import os
-from asyncio import sleep
 
 from textual import on
 from textual import events
@@ -531,7 +530,7 @@ def main() -> None:
             Debugger = GDBMiDebugger(ba, bs, ra, rs, base_pid=bpid, regression_pid=rpid)
 
     elif comparator == 'lldb':
-        from idd.debuggers.lldb.lldb_driver import LLDBParallelDebugger, LLDBDebugger
+        from idd.debuggers.lldb.lldb_driver import LLDBDebugger
         from idd.debuggers.lldb.lldb_new_driver import LLDBNewDriver
 
         if ra == "" and rpid is None:

--- a/src/idd/cli.py
+++ b/src/idd/cli.py
@@ -126,7 +126,7 @@ class DiffDebug(App):
             self.diff_area2.append(diff2)
     
     async def set_pframes_result(self, state, version) -> None:
-        if state == None or "stack_frames" not in state:
+        if state is None or "stack_frames" not in state:
             return
 
         file_contents = state["stack_frames"]
@@ -136,7 +136,7 @@ class DiffDebug(App):
             self.diff_frames2.text(file_contents)
 
     async def set_pframes_command_result(self, state) -> None:
-        if state["base"] == None or "stack_frames" not in state["base"] or state["regressed"] == None or "stack_frames" not in state["regressed"]:
+        if state["base"] is None or "stack_frames" not in state["base"] or state["regressed"] is None or "stack_frames" not in state["regressed"]:
             return
 
         base_file_contents = state["base"]["stack_frames"]
@@ -149,7 +149,7 @@ class DiffDebug(App):
         self.diff_frames2.text(diff2)
 
     async def set_plocals_result(self, state, version) -> None:
-        if state == None or "locals" not in state:
+        if state is None or "locals" not in state:
             return
         
         file_contents = state["locals"]
@@ -160,7 +160,7 @@ class DiffDebug(App):
 
 
     async def set_plocals_command_result(self, state) -> None:
-        if state["base"] == None or "locals" not in state["base"] or state["regressed"] == None or "locals" not in state["regressed"]:
+        if state["base"] is None or "locals" not in state["base"] or state["regressed"] is None or "locals" not in state["regressed"]:
             return
 
         base_file_contents = state["base"]["locals"]
@@ -173,7 +173,7 @@ class DiffDebug(App):
         self.diff_locals2.text(diff2)
 
     async def set_pargs_result(self, state, version) -> None:
-        if state == None or "args" not in state:
+        if state is None or "args" not in state:
             return
         
         file_contents = state["args"]
@@ -183,7 +183,7 @@ class DiffDebug(App):
             self.diff_args2.text(file_contents)
 
     async def set_pargs_command_result(self, state) -> None:
-        if state["base"] == None or "args" not in state["base"] or state["regressed"] == None or "args" not in state["regressed"]:
+        if state["base"] is None or "args" not in state["base"] or state["regressed"] is None or "args" not in state["regressed"]:
             return
 
         base_file_contents = state["base"]["args"]
@@ -196,7 +196,7 @@ class DiffDebug(App):
         self.diff_args2.text(diff2)
 
     async def set_pasm_result(self, state, version) -> None:
-        if state == None or "instructions" not in state:
+        if state is None or "instructions" not in state:
             return
         
         file_contents = state["instructions"]
@@ -206,7 +206,7 @@ class DiffDebug(App):
             self.diff_asm2.text(file_contents)
 
     async def set_pasm_command_result(self, state) -> None:
-        if state["base"] == None or "instructions" not in state["base"] or state["regressed"] == None or "instructions" not in state["regressed"]:
+        if state["base"] is None or "instructions" not in state["base"] or state["regressed"] is None or "instructions" not in state["regressed"]:
             return
 
         base_file_contents = state["base"]["instructions"]
@@ -219,7 +219,7 @@ class DiffDebug(App):
         self.diff_asm2.text(diff2)
 
     async def set_pregisters_result(self, state, version) -> None:
-        if state == None or "registers" not in state:
+        if state is None or "registers" not in state:
             return
         
         file_contents = state["registers"]
@@ -229,7 +229,7 @@ class DiffDebug(App):
             self.diff_reg2.text(file_contents)
 
     async def set_pregisters_command_result(self, state) -> None:
-        if state["base"] == None or "registers" not in state["base"] or state["regressed"] == None or "registers" not in state["regressed"]:
+        if state["base"] is None or "registers" not in state["base"] or state["regressed"] is None or "registers" not in state["regressed"]:
             return
 
         base_file_contents = state["base"]["registers"]

--- a/src/idd/debuggers/gdb/gdb_commands.py
+++ b/src/idd/debuggers/gdb/gdb_commands.py
@@ -64,13 +64,13 @@ class PrintState (gdb.Command):
             # get locals
             if (symbol.is_variable):
                 name = symbol.name
-                if not name in names:
+                if name not in names:
                     locals.append('{} = {}'.format(name, symbol.value(frame)).replace('"',''))
 
             # get args
             if (symbol.is_argument):
                 name = symbol.name
-                if not name in names:
+                if name not in names:
                     args.append('{} = {}\n'.format(name, symbol.value(frame)).replace('"',''))
         block = block.superblock
 
@@ -136,7 +136,7 @@ class PrintLocals (gdb.Command):
         for symbol in block:
             if (symbol.is_variable):
                 name = symbol.name
-                if not name in names:
+                if name not in names:
                     print('{} = {}'.format(name, symbol.value(frame)))
                     names.add(name)
         block = block.superblock
@@ -153,7 +153,7 @@ class PrintArgs (gdb.Command):
         for symbol in block:
             if (symbol.is_argument):
                 name = symbol.name
-                if not name in names:
+                if name not in names:
                     print('{} = {}\n'.format(name, symbol.value(frame)))
                     names.add(name)
         block = block.superblock
@@ -216,7 +216,7 @@ class RunWrapper (gdb.Command):
     try:
       result = gdb.execute(arg, to_string=True)
       print(result)
-    except Exception as ex:
+    except Exception:
       ex_type, ex_value, ex_traceback = sys.exc_info()
       # Extract unformatter stack traces as tuples
       trace_back = traceback.extract_tb(ex_traceback)

--- a/src/idd/debuggers/gdb/gdb_driver.py
+++ b/src/idd/debuggers/gdb/gdb_driver.py
@@ -1,15 +1,10 @@
-from pygdbmi.gdbcontroller import GdbController
-from pprint import pprint
 from idd.driver import Driver
 
-import io
-import time
 import subprocess
 import selectors
-import sys
-import os, fcntl
-import select, time
-import threading, queue
+import os
+import fcntl
+import threading
 
 base_response = ""
 regressed_response = ""

--- a/src/idd/debuggers/gdb/gdb_driver.py
+++ b/src/idd/debuggers/gdb/gdb_driver.py
@@ -261,14 +261,14 @@ class GDBDebugger(Driver):
 
         if version == "base":
             while True:
-                if base_response != None:
+                if base_response is not None:
                     temp = base_response
                     base_response = ""
                     break
 
         if version == "regressed":
             while True:
-                if regressed_response != None:
+                if regressed_response is not None:
                     temp = regressed_response
                     regressed_response = ""
                     break

--- a/src/idd/debuggers/gdb/gdb_mi_driver.py
+++ b/src/idd/debuggers/gdb/gdb_mi_driver.py
@@ -1,6 +1,7 @@
 import os
 import json
-import logging, threading
+import logging
+import threading
 
 from pygdbmi import gdbmiparser
 
@@ -122,7 +123,7 @@ class GDBMiDebugger(Driver):
             self.gdb_instances[version].write(command)
             raw_result = self.gdb_instances[version].read_until_prompt()
 
-        except Exception as e:
+        except Exception:
             logger.exception(f"Error executing GDB command: {command}")
             # self.handle_gdb_crash()
             return []
@@ -137,7 +138,7 @@ class GDBMiDebugger(Driver):
             #self.gdb_instances[version].flush_debuggee_output()
             self.gdb_instances[version].write(command)
             raw_result = self.gdb_instances[version].read_until_prompt()
-        except Exception as e:
+        except Exception:
             logger.exception(f"Error executing GDB command: {command}")
             # self.handle_gdb_crash()
             return []

--- a/src/idd/debuggers/gdb/idd_gdb_controller.py
+++ b/src/idd/debuggers/gdb/idd_gdb_controller.py
@@ -1,14 +1,11 @@
 import os
 import logging
-import select
 import fcntl
 import pty
 import signal
 import threading
 import time
 
-from idd.driver import IDDParallelTerminate
-from idd.debuggers.gdb.utils import parse_gdb_line
 
 from pygdbmi.gdbcontroller import GdbController
 

--- a/src/idd/debuggers/lldb/lldb_commands.py
+++ b/src/idd/debuggers/lldb/lldb_commands.py
@@ -65,8 +65,8 @@ def print_list(debugger, args, result, internal_dict):
 
         print(result)
         print("end_command")
-    except:
-        print("exception")
+    except Exception as e:
+        print("exception {e}")
         print("end_command")
 
 def run_wrapper(debugger, args, result, internal_dict):
@@ -78,8 +78,8 @@ def run_wrapper(debugger, args, result, internal_dict):
 
         print(command_result)
         print("end_command")
-    except:
-        print("exception")
+    except Exception as e:
+        print("exception {e}")
         print("end_command")
 
 def __lldb_init_module(debugger, internal_dict):

--- a/src/idd/debuggers/lldb/lldb_commands.py
+++ b/src/idd/debuggers/lldb/lldb_commands.py
@@ -65,7 +65,7 @@ def print_list(debugger, args, result, internal_dict):
 
         print(result)
         print("end_command")
-    except Exception as e:
+    except Exception:
         print("exception {e}")
         print("end_command")
 
@@ -78,7 +78,7 @@ def run_wrapper(debugger, args, result, internal_dict):
 
         print(command_result)
         print("end_command")
-    except Exception as e:
+    except Exception:
         print("exception {e}")
         print("end_command")
 

--- a/src/idd/debuggers/lldb/lldb_commands.py
+++ b/src/idd/debuggers/lldb/lldb_commands.py
@@ -1,9 +1,4 @@
 import lldb
-import sys
-import os
-import time
-from six import StringIO as SixStringIO
-import six
 import lldb_utils
 import json
 

--- a/src/idd/debuggers/lldb/lldb_controller.py
+++ b/src/idd/debuggers/lldb/lldb_controller.py
@@ -1,4 +1,6 @@
-import os, sys, pty, tty, select, threading
+import os
+import select
+import threading
 import platform
 import lldb
 from lldb import eLaunchFlagStopAtEntry

--- a/src/idd/debuggers/lldb/lldb_driver.py
+++ b/src/idd/debuggers/lldb/lldb_driver.py
@@ -2,7 +2,7 @@ import os
 import lldb
 
 from idd.driver import Driver, IDDParallelTerminate
-from idd.debuggers.lldb.lldb_extensions import *
+from idd.debuggers.lldb.lldb_extensions import get_current_stack_frame_from_target,get_args_as_list,get_local_vars_as_list,get_instructions_as_list,get_registers_as_list,get_call_instructions
 from multiprocessing import Process, Pipe
 
 

--- a/src/idd/debuggers/lldb/lldb_new_driver.py
+++ b/src/idd/debuggers/lldb/lldb_new_driver.py
@@ -1,6 +1,6 @@
 from idd.driver import Driver
 from idd.debuggers.lldb.lldb_controller import IDDLLDBController
-from idd.debuggers.lldb.lldb_extensions import *
+from idd.debuggers.lldb.lldb_extensions import get_current_stack_frame_from_target,get_args_as_list,get_local_vars_as_list,get_instructions_as_list,get_registers_as_list
 from concurrent.futures import ThreadPoolExecutor
 
 


### PR DESCRIPTION
The objective of this PR will be to fix all the linter issues with idd picked up by ruff. Before this PR ruff picked the up the following issues

```
ruff check --statistics 
20	F401	[*] unused-import
17	E711	[ ] none-comparison
13	F841	[ ] unused-variable
11	F405	[ ] undefined-local-with-import-star-usage
 5	E401	[*] multiple-imports-on-one-line
 4	E713	[*] not-in-test
 2	E722	[ ] bare-except
 2	F403	[ ] undefined-local-with-import-star
 2	F811	[ ] redefined-while-unused
Found 76 errors.
```

The first commit is the changes done by executing `ruff check --fix` on the repo to automatically fix F401, E401 and E713 . Each subsequent commit will fix one of the rules that is left. Once all rules have been fixed I will add a workflow which run the ruff linter over subsequent PRs . 